### PR TITLE
Provide actual filename header for image preview end-point

### DIFF
--- a/CASCToolHost/Controllers/PreviewController.cs
+++ b/CASCToolHost/Controllers/PreviewController.cs
@@ -56,7 +56,7 @@ namespace CASCToolHost.Controllers
 
             System.Net.Mime.ContentDisposition cd = new System.Net.Mime.ContentDisposition
             {
-                FileName = "preview",
+                FileName = Path.GetFileNameWithoutExtension(filename),
                 Inline = true
             };
 


### PR DESCRIPTION
When right-clicking to save an image from the wow.tools preview, browsers use the filename given by the content disposition header. When saving multiple files, having everything named "preview" and having to manually copy names can be cumbersome. This commit should provide the browser with the correct filename header.