### PR TITLE
Adding file size to content-disposition header for list file downloads

### DIFF
--- a/CASCToolHost/Controllers/ListfileController.cs
+++ b/CASCToolHost/Controllers/ListfileController.cs
@@ -25,9 +25,9 @@ namespace CASCToolHost.Controllers
             Logger.WriteLine("Serving listfile");
 
             var dataResponse = Encoding.ASCII.GetBytes(string.Join('\n', await Database.GetFiles(typeFilter)));
-
             var contentDispositionHeader = new ContentDispositionHeaderValue(DispositionTypeNames.Attachment)
             {
+                FileNameStar = "listfile.txt",
                 FileName = "listfile.txt",
                 Size = dataResponse.Length
             };
@@ -44,9 +44,9 @@ namespace CASCToolHost.Controllers
             var filesPerBuild = await Database.GetFilesByBuild(buildConfig, typeFilter);
 
             var dataResponse = Encoding.ASCII.GetBytes(string.Join('\n', filesPerBuild.Values));
-
             var contentDispositionHeader = new ContentDispositionHeaderValue(DispositionTypeNames.Attachment)
             {
+                FileNameStar = "listfile.txt",
                 FileName = "listfile.txt",
                 Size = dataResponse.Length
             };
@@ -68,9 +68,9 @@ namespace CASCToolHost.Controllers
             }
 
             var dataResponse = Encoding.ASCII.GetBytes(string.Join('\n', nameList.ToArray()));
-
             var contentDispositionHeader = new ContentDispositionHeaderValue(DispositionTypeNames.Attachment)
             {
+                FileNameStar = "listfile.csv",
                 FileName = "listfile.csv",
                 Size = dataResponse.Length
             };
@@ -92,9 +92,9 @@ namespace CASCToolHost.Controllers
             }
 
             var dataResponse = Encoding.ASCII.GetBytes(string.Join('\n', nameList.ToArray()));
-
             var contentDispositionHeader = new ContentDispositionHeaderValue(DispositionTypeNames.Attachment)
             {
+                FileNameStar = "listfile.csv",
                 FileName = "listfile.csv",
                 Size = dataResponse.Length
             };
@@ -118,9 +118,9 @@ namespace CASCToolHost.Controllers
             }
 
             var dataResponse = Encoding.ASCII.GetBytes(string.Join('\n', nameList.ToArray()));
-
             var contentDispositionHeader = new ContentDispositionHeaderValue(DispositionTypeNames.Attachment)
             {
+                FileNameStar = "listfile.csv",
                 FileName = "listfile.csv",
                 Size = dataResponse.Length
             };
@@ -137,9 +137,9 @@ namespace CASCToolHost.Controllers
 
             var unkFiles = await Database.GetUnknownFiles();
             var dataResponse = Encoding.ASCII.GetBytes(string.Join('\n', unkFiles));
-
             var contentDispositionHeader = new ContentDispositionHeaderValue(DispositionTypeNames.Attachment)
             {
+                FileNameStar = "unknown.csv",
                 FileName = "unknown.csv",
                 Size = dataResponse.Length
             };
@@ -158,9 +158,9 @@ namespace CASCToolHost.Controllers
             var unkFiles = await Database.GetUnknownLookups();
 
             var dataResponse = Encoding.ASCII.GetBytes(string.Join('\n', unkFiles));
-
             var contentDispositionHeader = new ContentDispositionHeaderValue(DispositionTypeNames.Attachment)
             {
+                FileNameStar = "unknownlookups.csv",
                 FileName = "unknownlookups.csv",
                 Size = dataResponse.Length
             };

--- a/CASCToolHost/Controllers/ListfileController.cs
+++ b/CASCToolHost/Controllers/ListfileController.cs
@@ -3,6 +3,8 @@ using Microsoft.AspNetCore.Mvc;
 using System.Collections.Generic;
 using System.Text;
 using System.Threading.Tasks;
+using Microsoft.Net.Http.Headers;
+using System.Net.Mime;
 
 namespace CASCToolHost.Controllers
 {
@@ -21,10 +23,19 @@ namespace CASCToolHost.Controllers
         public async Task<ActionResult> Download(string? typeFilter = null)
         {
             Logger.WriteLine("Serving listfile");
-            return new FileContentResult(Encoding.ASCII.GetBytes(string.Join('\n', await Database.GetFiles(typeFilter))), "text/plain")
+
+            //var dataResponse = Encoding.ASCII.GetBytes(string.Join('\n', await Database.GetFiles(typeFilter)));
+            var dataResponse = Encoding.ASCII.GetBytes("dfjhkebgfajwehgfj");
+            ContentDisposition contentDisposition = new()
             {
-                FileDownloadName = "listfile.txt"
+                FileName = "listfile.txt",
+                Size = dataResponse.Length,
+                DispositionType = DispositionTypeNames.Attachment
             };
+
+            Response.Headers[HeaderNames.ContentDisposition] = contentDisposition.ToString();
+
+            return new FileContentResult(dataResponse, "text/plain");
         }
 
         [Route("download/build/{buildConfig}")]
@@ -32,10 +43,20 @@ namespace CASCToolHost.Controllers
         {
             Logger.WriteLine("Serving listfile for build " + buildConfig);
             var filesPerBuild = await Database.GetFilesByBuild(buildConfig, typeFilter);
-            return new FileContentResult(Encoding.ASCII.GetBytes(string.Join('\n', filesPerBuild.Values)), "text/plain")
+
+            var dataResponse = Encoding.ASCII.GetBytes(string.Join('\n', filesPerBuild.Values));
+          
+            ContentDisposition contentDisposition = new()
             {
-                FileDownloadName = "listfile.txt"
+                FileName = "listfile.txt",
+                Size = dataResponse.Length,
+                DispositionType = DispositionTypeNames.Attachment
             };
+
+            Response.Headers[HeaderNames.ContentDisposition] = contentDisposition.ToString();
+
+            return new FileContentResult(dataResponse, "text/plain");
+
         }
 
         [Route("download/csv")]
@@ -49,10 +70,18 @@ namespace CASCToolHost.Controllers
                 nameList.Add(entry.Key + ";" + entry.Value.filename);
             }
 
-            return new FileContentResult(Encoding.ASCII.GetBytes(string.Join('\n', nameList.ToArray())), "text/plain")
+            var dataResponse = Encoding.ASCII.GetBytes(string.Join('\n', nameList.ToArray()));
+            
+            ContentDisposition contentDisposition = new()
             {
-                FileDownloadName = "listfile.csv"
+                FileName = "listfile.csv",
+                Size = dataResponse.Length,
+                DispositionType = DispositionTypeNames.Attachment
             };
+
+            Response.Headers[HeaderNames.ContentDisposition] = contentDisposition.ToString();
+
+            return new FileContentResult(dataResponse, "text/csv");
         }
 
         [Route("download/csv/unverified")]
@@ -66,10 +95,18 @@ namespace CASCToolHost.Controllers
                 nameList.Add(entry.Key + ";" + entry.Value.filename);
             }
 
-            return new FileContentResult(Encoding.ASCII.GetBytes(string.Join('\n', nameList.ToArray())), "text/plain")
+            var dataResponse = Encoding.ASCII.GetBytes(string.Join('\n', nameList.ToArray()));
+
+            ContentDisposition contentDisposition = new()
             {
-                FileDownloadName = "listfile.csv"
+                FileName = "listfile.csv",
+                Size = dataResponse.Length,
+                DispositionType = DispositionTypeNames.Attachment
             };
+
+            Response.Headers[HeaderNames.ContentDisposition] = contentDisposition.ToString();
+
+            return new FileContentResult(dataResponse, "text/csv");
         }
 
         [Route("download/csv/build")]
@@ -85,10 +122,18 @@ namespace CASCToolHost.Controllers
                 nameList.Add(entry.Key + ";" + entry.Value);
             }
 
-            return new FileContentResult(Encoding.ASCII.GetBytes(string.Join('\n', nameList.ToArray())), "text/plain")
+            var dataResponse = Encoding.ASCII.GetBytes(string.Join('\n', nameList.ToArray()));
+          
+            ContentDisposition contentDisposition = new()
             {
-                FileDownloadName = "listfile.csv"
+                FileName = "listfile.csv",
+                Size = dataResponse.Length,
+                DispositionType = DispositionTypeNames.Attachment
             };
+
+            Response.Headers[HeaderNames.ContentDisposition] = contentDisposition.ToString();
+
+            return new FileContentResult(dataResponse, "text/csv");
         }
 
         [Route("download/csv/unknown")]
@@ -97,11 +142,18 @@ namespace CASCToolHost.Controllers
             Logger.WriteLine("Serving unknown listfile");
 
             var unkFiles = await Database.GetUnknownFiles();
-
-            return new FileContentResult(Encoding.ASCII.GetBytes(string.Join('\n', unkFiles)), "text/plain")
+            var dataResponse = Encoding.ASCII.GetBytes(string.Join('\n', unkFiles));
+          
+            ContentDisposition contentDisposition = new()
             {
-                FileDownloadName = "unknown.csv"
+                FileName = "unknown.csv",
+                Size = dataResponse.Length,
+                DispositionType = DispositionTypeNames.Attachment
             };
+
+            Response.Headers[HeaderNames.ContentDisposition] = contentDisposition.ToString();
+
+            return new FileContentResult(dataResponse, "text/csv");
         }
 
 
@@ -112,10 +164,18 @@ namespace CASCToolHost.Controllers
 
             var unkFiles = await Database.GetUnknownLookups();
 
-            return new FileContentResult(Encoding.ASCII.GetBytes(string.Join('\n', unkFiles)), "text/plain")
+            var dataResponse = Encoding.ASCII.GetBytes(string.Join('\n', unkFiles));
+         
+            ContentDisposition contentDisposition = new()
             {
-                FileDownloadName = "unknownlookups.csv"
+                FileName = "unknownlookups.csv",
+                Size = dataResponse.Length,
+                DispositionType = DispositionTypeNames.Attachment
             };
+
+            Response.Headers[HeaderNames.ContentDisposition] = contentDisposition.ToString();
+
+            return new FileContentResult(dataResponse, "text/csv");
         }
     }
 }

--- a/CASCToolHost/Controllers/ListfileController.cs
+++ b/CASCToolHost/Controllers/ListfileController.cs
@@ -24,16 +24,15 @@ namespace CASCToolHost.Controllers
         {
             Logger.WriteLine("Serving listfile");
 
-            //var dataResponse = Encoding.ASCII.GetBytes(string.Join('\n', await Database.GetFiles(typeFilter)));
-            var dataResponse = Encoding.ASCII.GetBytes("dfjhkebgfajwehgfj");
-            ContentDisposition contentDisposition = new()
+            var dataResponse = Encoding.ASCII.GetBytes(string.Join('\n', await Database.GetFiles(typeFilter)));
+
+            var contentDispositionHeader = new ContentDispositionHeaderValue(DispositionTypeNames.Attachment)
             {
                 FileName = "listfile.txt",
-                Size = dataResponse.Length,
-                DispositionType = DispositionTypeNames.Attachment
+                Size = dataResponse.Length
             };
 
-            Response.Headers[HeaderNames.ContentDisposition] = contentDisposition.ToString();
+            Response.Headers[HeaderNames.ContentDisposition] = contentDispositionHeader.ToString();
 
             return new FileContentResult(dataResponse, "text/plain");
         }
@@ -45,18 +44,16 @@ namespace CASCToolHost.Controllers
             var filesPerBuild = await Database.GetFilesByBuild(buildConfig, typeFilter);
 
             var dataResponse = Encoding.ASCII.GetBytes(string.Join('\n', filesPerBuild.Values));
-          
-            ContentDisposition contentDisposition = new()
+
+            var contentDispositionHeader = new ContentDispositionHeaderValue(DispositionTypeNames.Attachment)
             {
                 FileName = "listfile.txt",
-                Size = dataResponse.Length,
-                DispositionType = DispositionTypeNames.Attachment
+                Size = dataResponse.Length
             };
 
-            Response.Headers[HeaderNames.ContentDisposition] = contentDisposition.ToString();
+            Response.Headers[HeaderNames.ContentDisposition] = contentDispositionHeader.ToString();
 
             return new FileContentResult(dataResponse, "text/plain");
-
         }
 
         [Route("download/csv")]
@@ -71,15 +68,14 @@ namespace CASCToolHost.Controllers
             }
 
             var dataResponse = Encoding.ASCII.GetBytes(string.Join('\n', nameList.ToArray()));
-            
-            ContentDisposition contentDisposition = new()
+
+            var contentDispositionHeader = new ContentDispositionHeaderValue(DispositionTypeNames.Attachment)
             {
                 FileName = "listfile.csv",
-                Size = dataResponse.Length,
-                DispositionType = DispositionTypeNames.Attachment
+                Size = dataResponse.Length
             };
 
-            Response.Headers[HeaderNames.ContentDisposition] = contentDisposition.ToString();
+            Response.Headers[HeaderNames.ContentDisposition] = contentDispositionHeader.ToString();
 
             return new FileContentResult(dataResponse, "text/csv");
         }
@@ -97,14 +93,13 @@ namespace CASCToolHost.Controllers
 
             var dataResponse = Encoding.ASCII.GetBytes(string.Join('\n', nameList.ToArray()));
 
-            ContentDisposition contentDisposition = new()
+            var contentDispositionHeader = new ContentDispositionHeaderValue(DispositionTypeNames.Attachment)
             {
                 FileName = "listfile.csv",
-                Size = dataResponse.Length,
-                DispositionType = DispositionTypeNames.Attachment
+                Size = dataResponse.Length
             };
 
-            Response.Headers[HeaderNames.ContentDisposition] = contentDisposition.ToString();
+            Response.Headers[HeaderNames.ContentDisposition] = contentDispositionHeader.ToString();
 
             return new FileContentResult(dataResponse, "text/csv");
         }
@@ -123,15 +118,14 @@ namespace CASCToolHost.Controllers
             }
 
             var dataResponse = Encoding.ASCII.GetBytes(string.Join('\n', nameList.ToArray()));
-          
-            ContentDisposition contentDisposition = new()
+
+            var contentDispositionHeader = new ContentDispositionHeaderValue(DispositionTypeNames.Attachment)
             {
                 FileName = "listfile.csv",
-                Size = dataResponse.Length,
-                DispositionType = DispositionTypeNames.Attachment
+                Size = dataResponse.Length
             };
 
-            Response.Headers[HeaderNames.ContentDisposition] = contentDisposition.ToString();
+            Response.Headers[HeaderNames.ContentDisposition] = contentDispositionHeader.ToString();
 
             return new FileContentResult(dataResponse, "text/csv");
         }
@@ -143,15 +137,14 @@ namespace CASCToolHost.Controllers
 
             var unkFiles = await Database.GetUnknownFiles();
             var dataResponse = Encoding.ASCII.GetBytes(string.Join('\n', unkFiles));
-          
-            ContentDisposition contentDisposition = new()
+
+            var contentDispositionHeader = new ContentDispositionHeaderValue(DispositionTypeNames.Attachment)
             {
                 FileName = "unknown.csv",
-                Size = dataResponse.Length,
-                DispositionType = DispositionTypeNames.Attachment
+                Size = dataResponse.Length
             };
 
-            Response.Headers[HeaderNames.ContentDisposition] = contentDisposition.ToString();
+            Response.Headers[HeaderNames.ContentDisposition] = contentDispositionHeader.ToString();
 
             return new FileContentResult(dataResponse, "text/csv");
         }
@@ -165,15 +158,14 @@ namespace CASCToolHost.Controllers
             var unkFiles = await Database.GetUnknownLookups();
 
             var dataResponse = Encoding.ASCII.GetBytes(string.Join('\n', unkFiles));
-         
-            ContentDisposition contentDisposition = new()
+
+            var contentDispositionHeader = new ContentDispositionHeaderValue(DispositionTypeNames.Attachment)
             {
                 FileName = "unknownlookups.csv",
-                Size = dataResponse.Length,
-                DispositionType = DispositionTypeNames.Attachment
+                Size = dataResponse.Length
             };
 
-            Response.Headers[HeaderNames.ContentDisposition] = contentDisposition.ToString();
+            Response.Headers[HeaderNames.ContentDisposition] = contentDispositionHeader.ToString();
 
             return new FileContentResult(dataResponse, "text/csv");
         }


### PR DESCRIPTION
Adding file size to content-disposition header so it's possible for any clients automating the download of the list files to drive a progress bar/pre allocation of a buffer from the content-disposition header.

Also amended the content-type for list file download requests to match the content-type returned.

Disc: havric#4418